### PR TITLE
disable dead-man-switch by default

### DIFF
--- a/lib/user_settings/default.js
+++ b/lib/user_settings/default.js
@@ -6,7 +6,7 @@ module.exports = {
   showAlgoPauseInfo: true,
   rebootAutomatically: false,
   showOnlyFavoritePairs: false,
-  dms: true,
+  dms: false,
   ga: false,
   chart: BFX_HF_CUSTOM,
   theme: DARK,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-ui-config",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "engines": {
     "node": ">=6"
   },


### PR DESCRIPTION
DMS cancels orders in all trading environments, not only on the self-hosted version, so this behavior may be harmful to newcomers that are not aware of it, thus shall be disabled by default